### PR TITLE
Fixing an issue with the size of cosmos upserts

### DIFF
--- a/content_loading/AzureCosmosDBNoSqlVectorSearch.py
+++ b/content_loading/AzureCosmosDBNoSqlVectorSearch.py
@@ -275,9 +275,12 @@ class AzureCosmosDBNoSqlVectorSearch(BasePydanticVectorStore):
             raise Exception("Texts can not be null or empty")
 
         for node in nodes:
-            metadata = node_to_metadata_dict(
-                node, remove_text=True, flat_metadata=self.flat_metadata
-            )
+            node_dict = node.dict()
+            metadata: Dict[str, Any] = node_dict.get("metadata", {})
+
+            metadata["document_id"] = node.ref_doc_id or "None"
+            metadata["doc_id"] = node.ref_doc_id or "None"
+            metadata["ref_doc_id"] = node.ref_doc_id or "None"
 
             entry = {
                 self._id_key: node.node_id,
@@ -286,6 +289,7 @@ class AzureCosmosDBNoSqlVectorSearch(BasePydanticVectorStore):
                 self._metadata_key: metadata,
                 "timeStamp": date.today().isoformat(),
             }
+            
             data_to_insert.append(entry)
             ids.append(node.node_id)
 

--- a/content_loading/image_model_reader.py
+++ b/content_loading/image_model_reader.py
@@ -78,7 +78,6 @@ class ImageModelReader(BaseReader):
         return [
             ImageDocument(
                 text=completion.choices[0].message.content,
-                image=image_document.image,
                 image_path=image_document.image_path,
                 image_url=image_document.image_url,
                 metadata=extra_info,


### PR DESCRIPTION
**Changes Made**
- Removing the base64 encoding from the image object
- Removing the additional _node fields since they are duplicative, and we are not using the readers.