### PR TITLE
fixed issue with AzureOpenAI arguments with managed identity

### DIFF
--- a/content_loading/function_app.py
+++ b/content_loading/function_app.py
@@ -173,7 +173,6 @@ def __create_openai_client(openaiConfig: OpenAISettings, auth: ContentLoadingCre
         kwargs["api_key"] = openaiConfig.apiKey
     else:
         kwargs["azure_ad_token_provider"] = auth.openai_token_provider
-        kwargs["use_azure_ad"] = True
 
     return AzureOpenAI(**kwargs)
 


### PR DESCRIPTION
This pull request includes a small change to the `content_loading/function_app.py` file. The change removes the `use_azure_ad` parameter when creating the `AzureOpenAI` client.

* [`content_loading/function_app.py`](diffhunk://#diff-252adb66348b2d0039ceab291c0ee0665e81b41dc49de6e242f0c514d65c3acbL176): Removed the `use_azure_ad` parameter from the `__create_openai_client` function.